### PR TITLE
[Docs] Fix Typo: Update colors from background to anchors

### DIFF
--- a/docs/mint.json
+++ b/docs/mint.json
@@ -8,7 +8,7 @@
     "dark": "#00789E",
     "ultraLight": "#FFDFF0",
     "ultraDark": "#00516A",
-    "background": {
+    "anchors": {
       "from": "#ED007D",
       "to": "#00A5D9"
     }


### PR DESCRIPTION
# Summary

The previous PR had a typo. The colors should have been defined for `anchors` instead of `background`